### PR TITLE
feat: 포토카드 전체/상세/마이갤러리/판매카드 API 구현 및 라우트 연결

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,17 +1,18 @@
-import express from "express"
+import express from "express";
 import { errorHandler } from "./middlewares/error.middleware.js";
+import photoRouter from "./routes/photoRoutes.js";
 
 const app = express();
 const PORT = 5000;
 
-app.use(express.json())
+app.use(express.json());
 
 //라우터 등록
-// app.use('/user', userRouter)
+app.use("/", photoRouter);
 
 //미들웨어
-app.use(errorHandler)
+app.use(errorHandler);
 
 app.listen(PORT, () => {
-    console.log(`서버가 작동 중 입니다. 포트 번호: ${PORT}`)
-})
+  console.log(`서버가 작동 중 입니다. 포트 번호: ${PORT}`);
+});

--- a/src/controllers/photoController.js
+++ b/src/controllers/photoController.js
@@ -1,0 +1,80 @@
+import photoService from "../services/photoService.js";
+
+// 전체 카드 목록 조회 (필터링, 정렬, 페이지네이션 포함)
+export async function getAllCards(req, res, next) {
+  try {
+    const {
+      filterType,
+      filterValue,
+      keyword,
+      sort,
+      page = 1,
+      take = 10,
+    } = req.query;
+
+    const cards = await photoService.getAllCards({
+      filterType,
+      filterValue,
+      keyword,
+      sort,
+      page,
+      take,
+    });
+
+    res.json(cards);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// 카드 상세 정보 조회
+export async function getCardDetail(req, res, next) {
+  try {
+    const card = await photoService.getCardDetail(
+      Number(req.params.id),
+      req.user?.id
+    );
+    res.json(card);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// 로그인한 유저의 전체 보유 카드 조회 (필터링, 페이지네이션 포함)
+export async function getMyCards(req, res, next) {
+  try {
+    const { filterType, filterValue, keyword, page = 1, take = 10 } = req.query;
+
+    const cards = await photoService.getMyCards({
+      userId: req.user.id,
+      page,
+      take,
+      keyword,
+      filterType,
+      filterValue,
+    });
+    res.json(cards);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// 로그인한 유저의 판매 중인 카드 목록 조회(for_sale) (필터링, 페이지네이션 포함)
+export async function getMySales(req, res, next) {
+  try {
+    const { filterType, filterValue, keyword, page = 1, take = 10 } = req.query;
+
+    const sales = await photoService.getMySales({
+      userId: req.user.id,
+      page,
+      take,
+      keyword,
+      filterType,
+      filterValue,
+    });
+
+    res.json(sales);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/repositories/photoRepository.js
+++ b/src/repositories/photoRepository.js
@@ -1,0 +1,342 @@
+import prisma from "../prisma/client.js";
+
+// 필터 조건 생성 함수
+function createFilterOption({ filterType, filterValue, keyword }) {
+  const where = {};
+
+  // 키워드 검색 (카드 이름 기준)
+  if (keyword) {
+    where.userCard = {
+      photoCard: {
+        name: { contains: keyword },
+      },
+    };
+  }
+
+  // 필터 타입에 따른 필터링(한 번에 하나의 필터만 선택 가능)
+  if (filterType && filterValue) {
+    const values = filterValue.split(",");
+
+    switch (filterType) {
+      case "grade": // 등급
+        where.userCard ??= {};
+        where.userCard.photoCard ??= {};
+        where.userCard.photoCard.grade = { in: values };
+        break;
+      case "genre": // 장르
+        where.userCard ??= {};
+        where.userCard.photoCard ??= {};
+        where.userCard.photoCard.genre = { in: values };
+        break;
+      case "soldOut": // 매진 여부
+        where.remainingQuantity = values.includes("true") ? 0 : { gt: 0 };
+        break;
+      case "method": // 판매 방법
+        where.userCard ??= {};
+        where.userCard.status = { in: values };
+        break;
+    }
+  }
+
+  return where;
+}
+
+// 정렬 조건 생성 함수
+function createSortOption(sort) {
+  switch (sort) {
+    case "price-asc":
+      return [{ price: "asc" }];
+    case "price-desc":
+      return [{ price: "desc" }];
+    case "oldest":
+      return [{ createdAt: "asc" }];
+    case "latest":
+    default:
+      return [{ createdAt: "desc" }];
+  }
+}
+
+// 카드 타입 판별
+function getCardType(status, remainingQuantity) {
+  if (status === "FOR_SALE" && remainingQuantity === 0) return "soldout";
+  if (status === "FOR_SALE") return "for_sale";
+  if (status === "FOR_TRADE") return "exchange";
+  if (status === "IDLE") return "my_card";
+  return null;
+}
+
+// 상태 텍스트 변환
+function getSaleStatusText(status) {
+  switch (status) {
+    case "FOR_SALE":
+      return "판매 중";
+    case "FOR_TRADE":
+      return "교환 제시 대기 중";
+    case "SOLD":
+      return "거래 완료";
+    default:
+      return "보유 중";
+  }
+}
+
+// 전체 포토카드 목록 조회 (필터, 정렬, 페이지네이션 포함)
+export async function findAllCards({
+  filterType,
+  filterValue,
+  keyword,
+  sort,
+  page = 1,
+  take = 10,
+}) {
+  const skip = (Number(page) - 1) * Number(take); // 페이지네이션 offset
+  const orderBy = createSortOption(sort); // 정렬 조건
+  const where = createFilterOption({ filterType, filterValue, keyword }); // 필터 조건
+
+  const [totalCount, shops] = await Promise.all([
+    prisma.shop.count({ where }),
+    prisma.shop.findMany({
+      where,
+      orderBy,
+      skip,
+      take: Number(take),
+      include: {
+        userCard: {
+          include: {
+            photoCard: true,
+            user: true,
+          },
+        },
+      },
+    }),
+  ]);
+
+  const result = shops.map((shop) => {
+    const { userCard } = shop;
+    const { photoCard, user } = userCard;
+
+    return {
+      cardId: photoCard.id,
+      userCardId: userCard.id,
+      imageUrl: photoCard.imageUrl,
+      price: shop.price,
+      title: photoCard.name,
+      description: photoCard.description ?? "",
+      cardGenre: photoCard.genre,
+      cardGrade: photoCard.grade,
+      nickname: user?.nickname ?? null,
+      quantityLeft: shop.remainingQuantity,
+      quantityTotal: shop.initialQuantity,
+      saleStatus: getSaleStatusText(userCard.status),
+      type: getCardType(userCard.status, shop.remainingQuantity),
+      createdAt: shop.createdAt,
+      updatedAt: shop.updatedAt,
+    };
+  });
+
+  return {
+    totalCount,
+    currentPage: Number(page),
+    totalPages: Math.ceil(totalCount / Number(take)),
+    result,
+  };
+}
+
+// 카드 상세 조회
+export async function findCardById(userCardId, currentUserId) {
+  const userCard = await prisma.userCard.findUnique({
+    where: { id: userCardId },
+    include: {
+      photoCard: true,
+      shop: true,
+      user: true,
+    },
+  });
+
+  if (!userCard) throw new Error("카드 정보를 찾을 수 없습니다.");
+
+  const { photoCard, shop, user } = userCard;
+  const isSeller = userCard.userId === currentUserId; // 판매자 or 구매자 판별
+
+  const baseData = {
+    cardId: photoCard.id,
+    userCardId: userCard.id,
+    imageUrl: photoCard.imageUrl,
+    title: photoCard.name,
+    description: photoCard.description,
+    cardGenre: photoCard.genre,
+    cardGrade: photoCard.grade,
+    price: shop?.price,
+    nickname: user.nickname,
+    quantityLeft: shop?.remainingQuantity,
+    quantityTotal: shop?.initialQuantity,
+    saleStatus: userCard.status,
+    type: getCardType(userCard.status, shop?.remainingQuantity),
+    isSeller,
+    createdAt: userCard.createdAt,
+    updatedAt: userCard.updatedAt,
+  };
+
+  // TODO: 추후 api 연동 후 수정 예정
+  // 판매자일 경우: 교환 제안 목록 조회
+  if (isSeller) {
+    const exchanges = await prisma.exchange.findMany({
+      where: { targetCardId: userCard.id },
+      include: {
+        requester: { select: { nickname: true } },
+        offeredCard: {
+          include: {
+            photoCard: true,
+          },
+        },
+      },
+    });
+
+    baseData.exchangeProposals = exchanges.map((ex) => ({
+      exchangeId: ex.id,
+      requesterNickname: ex.requester.nickname,
+      offeredCardId: ex.offeredCard.id,
+      offeredCardName: ex.offeredCard.photoCard.name,
+      offeredCardGrade: ex.offeredCard.photoCard.grade,
+      offeredCardGenre: ex.offeredCard.photoCard.genre,
+    }));
+  }
+
+  // 구매자일 경우: 교환 정보 제공
+  if (!isSeller && shop) {
+    baseData.exchangeInfo = {
+      genre: shop.exchangeGenre,
+      grade: shop.exchangeGrade,
+      description: shop.exchangeDescription,
+    };
+  }
+
+  return baseData;
+}
+
+// 내가 가진 카드 조회 (페이지네이션 포함)
+export async function findMyCards({
+  userId,
+  filterType,
+  filterValue,
+  keyword,
+  page = 1,
+  take = 10,
+}) {
+  const skip = (Number(page) - 1) * Number(take);
+  const extraWhere = createFilterOption({ filterType, filterValue, keyword });
+
+  const where = {
+    userId,
+    status: "IDLE", // 순수 보유 카드
+    ...extraWhere?.userCard,
+  };
+
+  const [totalCount, userCards] = await Promise.all([
+    prisma.userCard.count({ where }),
+    prisma.userCard.findMany({
+      where,
+      include: {
+        photoCard: true,
+        shop: true,
+      },
+      orderBy: [{ createdAt: "desc" }],
+      skip,
+      take: Number(take),
+    }),
+  ]);
+
+  const list = userCards.map((card) => ({
+    userCardId: card.id,
+    imageUrl: card.photoCard.imageUrl,
+    title: card.photoCard.name,
+    description: card.photoCard.description,
+    cardGenre: card.photoCard.genre,
+    cardGrade: card.photoCard.grade,
+    status: card.status,
+    saleStatus: getSaleStatusText(card.status),
+    type: getCardType(card.status, card.shop?.remainingQuantity),
+    createdAt: card.createdAt,
+    updatedAt: card.updatedAt,
+  }));
+
+  return {
+    totalCount,
+    currentPage: Number(page),
+    totalPages: Math.ceil(totalCount / Number(take)),
+    list,
+  };
+}
+
+// 내가 등록한 판매 카드 조회 (페이지네이션 포함)
+export async function findMySales({
+  userId,
+  filterType,
+  filterValue,
+  keyword,
+  page = 1,
+  take = 10,
+}) {
+  const skip = (Number(page) - 1) * Number(take);
+  const extraWhere = createFilterOption({ filterType, filterValue, keyword });
+
+  const where = {
+    sellerId: userId,
+    remainingQuantity: { gte: 0 }, // 판매등록된 카드
+    ...extraWhere,
+  };
+
+  const [totalCount, shops] = await Promise.all([
+    prisma.shop.count({ where }),
+    prisma.shop.findMany({
+      where,
+      include: {
+        userCard: {
+          include: {
+            photoCard: true,
+            user: true,
+          },
+        },
+      },
+      orderBy: [{ createdAt: "desc" }],
+      skip,
+      take: Number(take),
+    }),
+  ]);
+
+  const list = shops.map((shop) => ({
+    shopId: shop.id,
+    userCardId: shop.userCard.id,
+    imageUrl: shop.userCard.photoCard.imageUrl,
+    title: shop.userCard.photoCard.name,
+    description: shop.userCard.photoCard.description,
+    cardGenre: shop.userCard.photoCard.genre,
+    cardGrade: shop.userCard.photoCard.grade,
+    price: shop.price,
+    quantityLeft: shop.remainingQuantity,
+    quantityTotal: shop.initialQuantity,
+    saleStatus: getSaleStatusText(shop.userCard.status),
+    type: getCardType(shop.userCard.status, shop.remainingQuantity),
+    exchangeInfo: {
+      genre: shop.exchangeGenre,
+      grade: shop.exchangeGrade,
+      description: shop.exchangeDescription,
+    },
+    nickname: shop.userCard.user?.nickname ?? null,
+    createdAt: shop.createdAt,
+    updatedAt: shop.updatedAt,
+  }));
+
+  return {
+    totalCount,
+    currentPage: Number(page),
+    totalPages: Math.ceil(totalCount / Number(take)),
+    list,
+  };
+}
+
+export default {
+  findAllCards,
+  findCardById,
+  findMyCards,
+  findMySales,
+};

--- a/src/routes/photoRoutes.js
+++ b/src/routes/photoRoutes.js
@@ -1,0 +1,23 @@
+import express from "express";
+import {
+  getAllCards,
+  getCardDetail,
+  getMyCards,
+  getMySales,
+} from "../controllers/photoController.js";
+// import authMiddleware from "../middlewares/auth.middleware.js";
+
+const router = express.Router();
+
+router.get("/cards", getAllCards);
+router.get("/cards/:id", getCardDetail);
+router.get("/mypage/cards", (req, res, next) => {
+  req.user = { id: 2 }; // 임시 로그인 사용자 ID
+  getMyCards(req, res, next);
+});
+router.get("/mypage/sales", (req, res, next) => {
+  req.user = { id: 2 }; // 임시 로그인 사용자 ID
+  getMySales(req, res, next);
+});
+
+export default router;

--- a/src/services/photoService.js
+++ b/src/services/photoService.js
@@ -1,0 +1,24 @@
+import photoRepository from "../repositories/photoRepository.js";
+
+export async function getAllCards(query) {
+  return photoRepository.findAllCards(query);
+}
+
+export async function getCardDetail(id) {
+  return photoRepository.findCardById(id);
+}
+
+export async function getMyCards(query) {
+  return photoRepository.findMyCards(query);
+}
+
+export async function getMySales(query) {
+  return photoRepository.findMySales(query);
+}
+
+export default {
+  getAllCards,
+  getCardDetail,
+  getMyCards,
+  getMySales,
+};


### PR DESCRIPTION
## 작업 개요
- 포토카드 관련 기능 API 구현 및 라우팅 설정 완료

## 주요 변경 사항
- 전체 포토카드 조회 (필터, 정렬, 페이지네이션 포함)

- 포토카드 상세 조회 (판매자/구매자 구분, 교환 정보 포함) > 추후 수정 필요

- 마이 갤러리(내 전체 카드) 조회
  - 상태가 IDLE인 카드만 조회
  - 키워드 검색, 필터링, 페이지네이션 적용
  
- 나의 판매 포토카드 조회
  - 필터(등급, 장르, 매진여부, 판매방법) 적용
  - 페이지네이션 및 교환 정보 포함

## 폴더 구조 적용
- controller / service / repository 계층 구조에 맞춰 분리
- `photoRoutes.js` 라우터 등록 및 `app.js`에 연결