### PR TITLE
[수정] 사용자 정보 응답에서 포인트 중복 제거

### DIFF
--- a/.http/user.http
+++ b/.http/user.http
@@ -16,7 +16,7 @@ Cookie: refreshToken=yJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI
 
 ### 내 정보 조회
 GET {{baseUrl}}/api/users/me
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTc0NzgxNzY0NSwiZXhwIjoxNzQ3ODIxMjQ1fQ.aAgMGXjyKOJgqryenfyvNQQcQBpJjpzv6zOAN0Kfxos
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTc0Nzg5ODg1OSwiZXhwIjoxNzQ3OTAyNDU5fQ.dX9DSLB9tfxBV_amiHgJLHq9cY62354-iEpioBlgalw
 
 ### 내 정보 수정
 PATCH {{baseUrl}}/api/users/me

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -132,13 +132,17 @@ async function changePassword(id, currentPassword, newPassword) {
 
 // 비밀번호 등 민감 정보 제거
 function filterUser(user) {
-  const {encryptedPassword, refreshToken, ...safeUser} = user;
+  if (!user) {
+    throw new Error('user 객체가 null 또는 undefined입니다.');
+  }
+  const {encryptedPassword, refreshToken, point, ...safeUser} = user;
 
   // 포인트 정보 가공
-  return {
+  const result = {
     ...safeUser,
-    pointBalance: user.point?.balance || 0,
+    pointBalance: point?.balance || 0,
   };
+  return result;
 }
 
 export default {


### PR DESCRIPTION
- filterUser 함수에서 point 객체와 pointBalance 중복 발생 수정
- `point: { balance: 16000 }` + `pointBalance: 16000` 동시 존재
- point 객체를 분리하고 pointBalance만 반환하도록 변경